### PR TITLE
feat: version handling & concurrency control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-json v0.26.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.16.4
@@ -17,7 +18,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -29,9 +29,9 @@ func TestServer_AzAPI(t *testing.T) {
 	require.NotNil(t, schema)
 
 	// Check that we got actual schema data
-	var resourceSchemas map[string]*tfjson.Schema = schema.ResourceSchemas
-	var dataSourceSchemas map[string]*tfjson.Schema = schema.DataSourceSchemas
-	var ephemeralResourceSchemas map[string]*tfjson.Schema = schema.EphemeralResourceSchemas
+	var resourceSchemas = schema.ResourceSchemas
+	var dataSourceSchemas = schema.DataSourceSchemas
+	var ephemeralResourceSchemas = schema.EphemeralResourceSchemas
 	providerSchema := schema.ConfigSchema
 	require.NotNil(t, providerSchema, "Should have provider schema")
 

--- a/versions.go
+++ b/versions.go
@@ -1,0 +1,131 @@
+package tfpluginschema
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+const (
+	pluginApiVersions = "versions"
+)
+
+type pluginApiVersionsResponse struct {
+	Versions []struct {
+		Version string `json:"version"`
+	} `json:"versions"`
+}
+
+type VersionsRequest struct {
+	Namespace string
+	Name      string
+}
+
+func (v VersionsRequest) String() string {
+	sb := strings.Builder{}
+	sb.WriteString(pluginApi)
+	sb.WriteRune(urlPathSeparator)
+	sb.WriteString(v.Namespace)
+	sb.WriteRune(urlPathSeparator)
+	sb.WriteString(v.Name)
+	sb.WriteRune(urlPathSeparator)
+	sb.WriteString(pluginApiVersions)
+	result := sb.String()
+	if _, err := url.Parse(result); err != nil {
+		panic(fmt.Sprintf("failed to parse URL: %s, error: %v", result, err))
+	}
+	return result
+}
+
+// GetAvailableVersions fetches the available versions for the given provider from the plugin registry.
+// It caches the results to avoid redundant network calls.
+// It returns a sorted collection of versions.
+func (s *Server) GetAvailableVersions(req VersionsRequest) (goversion.Collection, error) {
+	l := s.l.With("request_namespace", req.Namespace, "request_name", req.Name)
+
+	s.mu.RLock()
+	if v, ok := s.versionsc[req]; ok {
+		s.mu.RUnlock()
+		l.Info("Request already exists in download cache")
+		return v, nil
+	}
+	s.mu.RUnlock()
+
+	var result pluginApiVersionsResponse
+
+	versionRequest, err := http.NewRequest(http.MethodGet, req.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for versions: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(versionRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get versions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get versions: %s => %d", req.String(), resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode versions response: %w", err)
+	}
+
+	var versions goversion.Collection
+	for _, v := range result.Versions {
+		ver, err := goversion.NewVersion(v.Version)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse version %q: %w", v.Version, err)
+		}
+		versions = append(versions, ver)
+	}
+
+	slices.SortFunc(versions, func(a, b *goversion.Version) int {
+		return a.Compare(b)
+	})
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.versionsc[req] = versions
+	return versions, nil
+}
+
+// GetLatestVersionMatch returns the latest version from the provided collection that matches the given constraints.
+// The versions collection must be sorted in ascending order.
+// If no versions match the constraints, an error is returned.
+// If the constraints are nil or empty, the latest version is returned.
+func GetLatestVersionMatch(versions goversion.Collection, constraints goversion.Constraints) (*goversion.Version, error) {
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no versions provided")
+	}
+
+	if !slices.IsSortedFunc(versions, func(a, b *goversion.Version) int {
+		return a.Compare(b)
+	}) {
+		return nil, fmt.Errorf("versions are not sorted")
+	}
+
+	// return latest if no constraints
+	if constraints == nil || constraints.Len() == 0 {
+		return versions[len(versions)-1], nil
+	}
+
+	var lastGood *goversion.Version
+	for _, v := range versions {
+		if constraints.Check(v) {
+			lastGood = v
+		}
+	}
+
+	if lastGood == nil {
+		return nil, fmt.Errorf("no matching version found")
+	}
+
+	return lastGood, nil
+}

--- a/versions_test.go
+++ b/versions_test.go
@@ -1,0 +1,105 @@
+package tfpluginschema
+
+import (
+	"testing"
+
+	goversion "github.com/hashicorp/go-version"
+)
+
+// helper to build versions slice already sorted
+func mustVersions(t *testing.T, vs ...string) goversion.Collection {
+	t.Helper()
+	out := make(goversion.Collection, 0, len(vs))
+	for _, s := range vs {
+		v, err := goversion.NewVersion(s)
+		if err != nil {
+			t.Fatalf("parse version %s: %v", s, err)
+		}
+		out = append(out, v)
+	}
+	// rely on caller to pass in sorted order; tests for unsorted case craft unsorted manually
+	return out
+}
+
+func mustConstraints(t *testing.T, c string) goversion.Constraints {
+	t.Helper()
+	cons, err := goversion.NewConstraint(c)
+	if err != nil {
+		t.Fatalf("constraint %s: %v", c, err)
+	}
+	return cons
+}
+
+func TestGetLatestVersionMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		versions    goversion.Collection
+		constraints goversion.Constraints
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "empty versions",
+			versions:    goversion.Collection{},
+			constraints: mustConstraints(t, ">= 1.0.0"),
+			wantErr:     true,
+		},
+		{
+			name:        "nil constraints",
+			versions:    mustVersions(t, "1.0.0", "1.1.0"),
+			constraints: nil,
+			want:        "1.1.0",
+		},
+		{
+			name:        "empty constraints slice returns latest version",
+			versions:    mustVersions(t, "1.0.0", "1.2.0", "2.0.0"),
+			constraints: goversion.Constraints{},
+			want:        "2.0.0",
+		},
+		{
+			name:        "unsorted versions returns error",
+			versions:    func() goversion.Collection { v := mustVersions(t, "1.0.0", "0.9.0"); return v }(),
+			constraints: mustConstraints(t, ">= 0.1.0"),
+			wantErr:     true,
+		},
+		{
+			name:        "no matching version",
+			versions:    mustVersions(t, "1.0.0", "1.1.0", "1.2.0"),
+			constraints: mustConstraints(t, "< 1.0.0"),
+			wantErr:     true,
+		},
+		{
+			name:        "range picks highest match",
+			versions:    mustVersions(t, "0.9.0", "1.0.0", "1.5.0", "1.9.9", "2.0.0"),
+			constraints: mustConstraints(t, ">= 1.0.0, < 2.0.0"),
+			want:        "1.9.9",
+		},
+		{
+			name:        "constraint matches last (latest) version",
+			versions:    mustVersions(t, "1.0.0", "1.1.0", "1.2.0"),
+			constraints: mustConstraints(t, ">= 1.2.0"),
+			want:        "1.2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := GetLatestVersionMatch(tt.versions, tt.constraints)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none (result=%v)", v)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if v == nil {
+				t.Fatalf("expected version %s, got nil", tt.want)
+			}
+			if got := v.String(); got != tt.want {
+				t.Fatalf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds support for fetching and caching available provider versions, and for automatically selecting the latest version when none is specified. It introduces a new `versions.go` module, integrates version management into the main `Server` logic, and ensures thread-safe access to caches using a read-write mutex. The changes improve reliability and usability by handling version selection transparently and preventing race conditions in concurrent environments.

**Version management and selection:**

* Added a new `versions.go` module with `GetAvailableVersions` and `GetLatestVersionMatch` functions to fetch, cache, and select provider versions from the registry, including constraints support.
* Integrated automatic selection of the latest provider version in `Server.Get` and `Server.getSchema` when no version is specified, using the new version management logic. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R123-R142) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R503-R533) [[3]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R552-R579)

**Thread safety improvements:**

* Introduced a read-write mutex (`mu *sync.RWMutex`) and updated all cache accesses (`dlc`, `sc`, `versionsc`) to use appropriate locking for thread safety. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R79-R88) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R105-R106) [[3]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R123-R142) [[4]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R245-R252) [[5]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R263-R275) [[6]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R289-R300) [[7]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R314-R325) [[8]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R338-R349) [[9]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R363-R394) [[10]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R413-R425) [[11]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R444-R455) [[12]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R474-R485) [[13]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R503-R533) [[14]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R552-R579)

**Testing and dependency updates:**

* Added `versions_test.go` with comprehensive unit tests for version selection logic, including constraint handling and error cases.
* Updated `go.mod` to add a direct dependency on `github.com/hashicorp/go-version v1.7.0`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R8) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L20)

**Minor code cleanups:**

* Simplified type declarations in `server_integration_test.go` for readability.

**Imports and struct changes:**

* Updated imports and the `Server` struct to support new version management and synchronization features. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R17-R19) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R79-R88) [[3]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R105-R106)

These changes collectively make provider version handling robust, transparent, and safe for concurrent use.