### PR TITLE
fix: always use fixed version for cache key

### DIFF
--- a/server.go
+++ b/server.go
@@ -138,9 +138,12 @@ func (s *Server) Cleanup() {
 func (s *Server) Get(request Request) error {
 	l := s.l.With("request_namespace", request.Namespace, "request_name", request.Name, "request_version", request.Version)
 
-	var err error
-	if request, err = request.fixVersion(s); err != nil {
-		return err
+	if !request.fixedVersion() {
+		var err error
+		request, err = request.fixVersion(s)
+		if err != nil {
+			return err
+		}
 	}
 
 	s.mu.RLock()
@@ -275,6 +278,13 @@ func (s *Server) Get(request Request) error {
 func (s *Server) GetResourceSchema(request Request, resource string) (*tfjson.Schema, error) {
 	s.l.Info("Getting resource schema", "request", request, "resource", resource)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -301,6 +311,13 @@ func (s *Server) GetResourceSchema(request Request, resource string) (*tfjson.Sc
 func (s *Server) GetDataSourceSchema(request Request, dataSource string) (*tfjson.Schema, error) {
 	s.l.Info("Getting data source schema", "request", request, "data_source", dataSource)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -326,6 +343,13 @@ func (s *Server) GetDataSourceSchema(request Request, dataSource string) (*tfjso
 func (s *Server) GetFunctionSchema(request Request, function string) (*tfjson.FunctionSignature, error) {
 	s.l.Info("Getting function schema", "request", request, "function", function)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -349,6 +373,13 @@ func (s *Server) GetFunctionSchema(request Request, function string) (*tfjson.Fu
 // GetEphemeralResourceSchema retrieves the schema for a specific ephemeral resource from the provider.
 func (s *Server) GetEphemeralResourceSchema(request Request, ephemeralResource string) (*tfjson.Schema, error) {
 	s.l.Info("Getting ephemeral resource schema", "request", request, "ephemeral_resource", ephemeralResource)
+
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
 
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
@@ -375,6 +406,13 @@ func (s *Server) GetEphemeralResourceSchema(request Request, ephemeralResource s
 func (s *Server) GetProviderSchema(request Request) (*tfjson.Schema, error) {
 	s.l.Info("Getting provider schema", "request", request)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -393,6 +431,13 @@ func (s *Server) GetProviderSchema(request Request) (*tfjson.Schema, error) {
 // ListResources retrieves the list of resource names from the provider.
 func (s *Server) ListResources(request Request) ([]string, error) {
 	s.l.Info("Listing resources", "request", request)
+
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
 
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
@@ -425,6 +470,13 @@ func (s *Server) ListResources(request Request) ([]string, error) {
 func (s *Server) ListDataSources(request Request) ([]string, error) {
 	s.l.Info("Listing data sources", "request", request)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -456,6 +508,13 @@ func (s *Server) ListDataSources(request Request) ([]string, error) {
 func (s *Server) ListFunctions(request Request) ([]string, error) {
 	s.l.Info("Listing functions", "request", request)
 
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
+
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
 	s.mu.RUnlock()
@@ -485,6 +544,13 @@ func (s *Server) ListFunctions(request Request) ([]string, error) {
 // ListEphemeralResources retrieves the list of ephemeral resource names from the provider.
 func (s *Server) ListEphemeralResources(request Request) ([]string, error) {
 	s.l.Info("Listing ephemeral resources", "request", request)
+
+	if !request.fixedVersion() {
+		var err error
+		if request, err = request.fixVersion(s); err != nil {
+			return nil, err
+		}
+	}
 
 	s.mu.RLock()
 	schemaResp, ok := s.sc[request]
@@ -516,9 +582,8 @@ func (s *Server) ListEphemeralResources(request Request) ([]string, error) {
 func (s *Server) getSchema(request Request) (*tfjson.ProviderSchema, error) {
 	s.l.Info("Getting provider schema", "request", request)
 
-	var err error
-	if request, err = request.fixVersion(s); err != nil {
-		return nil, err
+	if !request.fixedVersion() {
+		return nil, fmt.Errorf("version must be fixed before getting schema")
 	}
 
 	s.mu.RLock()

--- a/server.go
+++ b/server.go
@@ -141,26 +141,6 @@ func (s *Server) readSchema(request Request) (*tfjson.ProviderSchema, error) {
 		return nil, errors.New("provider schema is nil but no error was returned")
 	}
 
-	if resp.DataSourceSchemas == nil {
-		resp.DataSourceSchemas = make(map[string]*tfjson.Schema)
-	}
-
-	if resp.ResourceSchemas == nil {
-		resp.ResourceSchemas = make(map[string]*tfjson.Schema)
-	}
-
-	if resp.EphemeralResourceSchemas == nil {
-		resp.EphemeralResourceSchemas = make(map[string]*tfjson.Schema)
-	}
-
-	if resp.Functions == nil {
-		resp.Functions = make(map[string]*tfjson.FunctionSignature)
-	}
-
-	if resp.ConfigSchema == nil {
-		resp.ConfigSchema = &tfjson.Schema{}
-	}
-
 	return resp, nil
 }
 
@@ -508,6 +488,28 @@ func (s *Server) getSchema(request Request) (*tfjson.ProviderSchema, error) {
 
 	if providerSchema == nil {
 		return nil, errors.New("provider schema is nil")
+	}
+
+	// Sanitize nil values to avoid nil dereference errors later
+	// (these should ideally never be nil, but just in case).
+	if providerSchema.DataSourceSchemas == nil {
+		providerSchema.DataSourceSchemas = make(map[string]*tfjson.Schema)
+	}
+
+	if providerSchema.ResourceSchemas == nil {
+		providerSchema.ResourceSchemas = make(map[string]*tfjson.Schema)
+	}
+
+	if providerSchema.EphemeralResourceSchemas == nil {
+		providerSchema.EphemeralResourceSchemas = make(map[string]*tfjson.Schema)
+	}
+
+	if providerSchema.Functions == nil {
+		providerSchema.Functions = make(map[string]*tfjson.FunctionSignature)
+	}
+
+	if providerSchema.ConfigSchema == nil {
+		providerSchema.ConfigSchema = &tfjson.Schema{}
 	}
 
 	// cache and return

--- a/server.go
+++ b/server.go
@@ -516,17 +516,17 @@ func (s *Server) ListEphemeralResources(request Request) ([]string, error) {
 func (s *Server) getSchema(request Request) (*tfjson.ProviderSchema, error) {
 	s.l.Info("Getting provider schema", "request", request)
 
+	var err error
+	if request, err = request.fixVersion(s); err != nil {
+		return nil, err
+	}
+
 	s.mu.RLock()
 	if resp, exists := s.sc[request]; exists {
 		s.mu.RUnlock()
 		return resp, nil
 	}
 	s.mu.RUnlock()
-
-	var err error
-	if request, err = request.fixVersion(s); err != nil {
-		return nil, err
-	}
 
 	// Ensure the provider is downloaded
 	if err := s.Get(request); err != nil {

--- a/server_methods_test.go
+++ b/server_methods_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetDataSourceSchema_Success(t *testing.T) {
 	s := NewServer(nil)
 	t.Cleanup(s.Cleanup)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{
 		DataSourceSchemas: map[string]*tfjson.Schema{
 			"ds": {Block: &tfjson.SchemaBlock{}},
@@ -25,7 +25,7 @@ func TestGetDataSourceSchema_Success(t *testing.T) {
 
 func TestGetDataSourceSchema_NotFound(t *testing.T) {
 	s := NewServer(nil)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{DataSourceSchemas: map[string]*tfjson.Schema{}}
 	got, err := s.GetDataSourceSchema(req, "missing")
 	assert.Nil(t, got)
@@ -36,7 +36,7 @@ func TestGetDataSourceSchema_NotFound(t *testing.T) {
 func TestGetFunctionSchema_Success(t *testing.T) {
 	s := NewServer(nil)
 	t.Cleanup(s.Cleanup)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{
 		Functions: map[string]*tfjson.FunctionSignature{
 			"fn": {Summary: "ok"},
@@ -50,7 +50,7 @@ func TestGetFunctionSchema_Success(t *testing.T) {
 
 func TestGetFunctionSchema_NotFound(t *testing.T) {
 	s := NewServer(nil)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{Functions: map[string]*tfjson.FunctionSignature{}}
 	got, err := s.GetFunctionSchema(req, "missing")
 	assert.Nil(t, got)
@@ -61,7 +61,7 @@ func TestGetFunctionSchema_NotFound(t *testing.T) {
 func TestGetEphemeralResourceSchema_Success(t *testing.T) {
 	s := NewServer(nil)
 	t.Cleanup(s.Cleanup)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{
 		EphemeralResourceSchemas: map[string]*tfjson.Schema{
 			"er": {Block: &tfjson.SchemaBlock{}},
@@ -74,7 +74,7 @@ func TestGetEphemeralResourceSchema_Success(t *testing.T) {
 
 func TestGetEphemeralResourceSchema_NotFound(t *testing.T) {
 	s := NewServer(nil)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{EphemeralResourceSchemas: map[string]*tfjson.Schema{}}
 	got, err := s.GetEphemeralResourceSchema(req, "missing")
 	assert.Nil(t, got)
@@ -84,7 +84,7 @@ func TestGetEphemeralResourceSchema_NotFound(t *testing.T) {
 
 func TestGetResourceSchema_NotFound(t *testing.T) {
 	s := NewServer(nil)
-	req := Request{Namespace: "n", Name: "p", Version: "v"}
+	req := Request{Namespace: "n", Name: "p", Version: "1.2.3"}
 	s.sc[req] = &tfjson.ProviderSchema{ResourceSchemas: map[string]*tfjson.Schema{}}
 	got, err := s.GetResourceSchema(req, "missing")
 	assert.Nil(t, got)


### PR DESCRIPTION
This pull request refactors how provider schemas are retrieved and handled in the `Server` implementation. The main change is the introduction of a new helper method, `readSchema`, which centralizes logic for schema retrieval and version fixing, and ensures all schema-related methods use it for consistency. Additionally, the code now sanitizes nil schema maps to prevent nil dereference errors, and updates tests to use fixed version strings for requests.

### Refactoring and Centralization

* Added a new helper method `readSchema` to the `Server` type in `server.go`, consolidating logic for fixing provider version and retrieving schemas, and updated all schema-related methods to use this helper for consistency and error handling.
* Removed duplicated version fixing logic from `getSchema` and related methods, ensuring version is always fixed before schema retrieval. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R452-L530) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R161-R167)

### Error Handling and Robustness

* In `getSchema`, added logic to sanitize nil values for schema maps (`DataSourceSchemas`, `ResourceSchemas`, `EphemeralResourceSchemas`, `Functions`, `ConfigSchema`) to avoid nil dereference errors later in execution.
* Improved error reporting for cases where provider schema is unexpectedly nil, ensuring errors are surfaced clearly to callers. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R127-R146) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6R452-L530)

### Test Consistency

* Updated all test cases in `server_methods_test.go` to use requests with fixed version strings (e.g., `"1.2.3"`) instead of variable `"v"`, ensuring tests match the new version-fixing requirements. [[1]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L15-R15) [[2]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L28-R28) [[3]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L39-R39) [[4]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L53-R53) [[5]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L64-R64) [[6]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L77-R77) [[7]](diffhunk://#diff-558cd8c5553186c27075e667c170fb00ce801595875c3439a80827eef9311795L87-R87)

### Code Simplification

* Removed redundant cache checks and lock/unlock patterns in schema-related methods, relying on the centralized `readSchema` logic for cache and retrieval. [[1]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L278-L291) [[2]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L304-L315) [[3]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L329-L340) [[4]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L353-L364) [[5]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L378-L414) [[6]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L428-L445) [[7]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L459-L474) [[8]](diffhunk://#diff-366e46a40f6f60b4f7614eb0976bb51820364bf5ca6ccc4787eb49d7bdbef3e6L489-L504)

These changes make the schema retrieval process more robust and maintainable, reduce code duplication, and improve error handling throughout the server logic.