### PR TITLE
feat: add support for Terraform registry

### DIFF
--- a/server_example_test.go
+++ b/server_example_test.go
@@ -68,3 +68,66 @@ func ExampleNewServer() {
 	// Attribute: use_msi
 	// Attribute: use_oidc
 }
+
+// ExampleNewServer_terraformRegistry demonstrates how to use the Terraform registry
+// instead of the default OpenTofu registry.
+// It uses the HashiCorp random provider as an example.
+func ExampleNewServer_terraformRegistry() {
+	s := tfpluginschema.NewServer(nil)
+	defer s.Cleanup()
+	request := tfpluginschema.Request{
+		Namespace:    "Azure",
+		Name:         "azapi",
+		Version:      "2.5.0",
+		RegistryType: tfpluginschema.RegistryTypeTerraform,
+	}
+
+	provSchema, err := s.GetProviderSchema(request)
+	if err != nil {
+		panic(err)
+	}
+
+	attrs := make([]string, 0, len(provSchema.Block.Attributes))
+	for name := range provSchema.Block.Attributes {
+		attrs = append(attrs, name)
+	}
+	slices.Sort(attrs)
+	for _, name := range attrs {
+		fmt.Printf("Attribute: %s\n", name)
+	}
+
+	// Output:
+	// Attribute: auxiliary_tenant_ids
+	// Attribute: client_certificate
+	// Attribute: client_certificate_password
+	// Attribute: client_certificate_path
+	// Attribute: client_id
+	// Attribute: client_id_file_path
+	// Attribute: client_secret
+	// Attribute: client_secret_file_path
+	// Attribute: custom_correlation_request_id
+	// Attribute: default_location
+	// Attribute: default_name
+	// Attribute: default_tags
+	// Attribute: disable_correlation_request_id
+	// Attribute: disable_default_output
+	// Attribute: disable_terraform_partner_id
+	// Attribute: enable_preflight
+	// Attribute: endpoint
+	// Attribute: environment
+	// Attribute: ignore_no_op_changes
+	// Attribute: maximum_busy_retry_attempts
+	// Attribute: oidc_azure_service_connection_id
+	// Attribute: oidc_request_token
+	// Attribute: oidc_request_url
+	// Attribute: oidc_token
+	// Attribute: oidc_token_file_path
+	// Attribute: partner_id
+	// Attribute: skip_provider_registration
+	// Attribute: subscription_id
+	// Attribute: tenant_id
+	// Attribute: use_aks_workload_identity
+	// Attribute: use_cli
+	// Attribute: use_msi
+	// Attribute: use_oidc
+}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -9,128 +9,167 @@ import (
 )
 
 func TestServer_GetAvailableVersions(t *testing.T) {
-	s := NewServer(nil)
-	defer s.Cleanup()
-
-	req := VersionsRequest{
-		Namespace: "hashicorp",
-		Name:      "aws",
+	registries := []struct {
+		name         string
+		registryType RegistryType
+	}{
+		{"OpenTofu", RegistryTypeOpenTofu},
+		{"Terraform", RegistryTypeTerraform},
 	}
 
-	versions, err := s.GetAvailableVersions(req)
-	require.NoError(t, err)
-	require.NotNil(t, versions)
-	require.Greater(t, len(versions), 0, "Should have at least one version")
-	t.Log("Available versions:", versions)
+	for _, reg := range registries {
+		t.Run(reg.name, func(t *testing.T) {
+			s := NewServer(nil)
+			defer s.Cleanup()
+
+			req := VersionsRequest{
+				Namespace:    "hashicorp",
+				Name:         "aws",
+				RegistryType: reg.registryType,
+			}
+
+			versions, err := s.GetAvailableVersions(req)
+			require.NoError(t, err)
+			require.NotNil(t, versions)
+			require.Greater(t, len(versions), 0, "Should have at least one version")
+			t.Log("Available versions:", versions)
+		})
+	}
 }
 
 func TestServer_AzAPI(t *testing.T) {
-	s := NewServer(nil)
-	defer s.Cleanup()
-
-	request := Request{
-		Namespace: "Azure",
-		Name:      "azapi",
-		Version:   "2.5.0",
+	registries := []struct {
+		name         string
+		registryType RegistryType
+	}{
+		{"OpenTofu", RegistryTypeOpenTofu},
+		{"Terraform", RegistryTypeTerraform},
 	}
 
-	// Download and extract the provider
-	require.NoError(t, s.Get(request))
-	assert.Len(t, s.dlc, 1)
+	for _, reg := range registries {
+		t.Run(reg.name, func(t *testing.T) {
+			s := NewServer(nil)
+			defer s.Cleanup()
 
-	// Get schema
-	schema, err := s.getSchema(request)
-	require.NoError(t, err)
-	require.NotNil(t, schema)
+			request := Request{
+				Namespace:    "Azure",
+				Name:         "azapi",
+				Version:      "2.5.0",
+				RegistryType: reg.registryType,
+			}
 
-	// Check that we got actual schema data
-	var resourceSchemas = schema.ResourceSchemas
-	var dataSourceSchemas = schema.DataSourceSchemas
-	var ephemeralResourceSchemas = schema.EphemeralResourceSchemas
-	providerSchema := schema.ConfigSchema
-	require.NotNil(t, providerSchema, "Should have provider schema")
+			// Download and extract the provider
+			require.NoError(t, s.Get(request))
+			assert.Len(t, s.dlc, 1)
 
-	require.NotNil(t, resourceSchemas, "Should have resource_schemas field")
-	require.NotNil(t, dataSourceSchemas, "Should have data_source_schemas field")
-	require.NotNil(t, ephemeralResourceSchemas, "Should have ephemeral_resource_schemas field")
-	require.Greater(t, len(resourceSchemas), 0, "Should have resource schemas")
-	require.Greater(t, len(dataSourceSchemas), 0, "Should have data source schemas")
-	require.Greater(t, len(ephemeralResourceSchemas), 0, "Should have ephemeral resource schemas")
+			// Get schema
+			schema, err := s.getSchema(request)
+			require.NoError(t, err)
+			require.NotNil(t, schema)
 
-	t.Logf("Number of resource schemas: %d", len(resourceSchemas))
-	t.Logf("Number of data source schemas: %d", len(dataSourceSchemas))
-	t.Logf("Number of ephemeral resource schemas: %d", len(ephemeralResourceSchemas))
+			// Check that we got actual schema data
+			var resourceSchemas = schema.ResourceSchemas
+			var dataSourceSchemas = schema.DataSourceSchemas
+			var ephemeralResourceSchemas = schema.EphemeralResourceSchemas
+			providerSchema := schema.ConfigSchema
+			require.NotNil(t, providerSchema, "Should have provider schema")
 
-	// Log some resource names for verification
-	for name := range resourceSchemas {
-		t.Logf("Resource: %s", name)
+			require.NotNil(t, resourceSchemas, "Should have resource_schemas field")
+			require.NotNil(t, dataSourceSchemas, "Should have data_source_schemas field")
+			require.NotNil(t, ephemeralResourceSchemas, "Should have ephemeral_resource_schemas field")
+			require.Greater(t, len(resourceSchemas), 0, "Should have resource schemas")
+			require.Greater(t, len(dataSourceSchemas), 0, "Should have data source schemas")
+			require.Greater(t, len(ephemeralResourceSchemas), 0, "Should have ephemeral resource schemas")
+
+			t.Logf("Number of resource schemas: %d", len(resourceSchemas))
+			t.Logf("Number of data source schemas: %d", len(dataSourceSchemas))
+			t.Logf("Number of ephemeral resource schemas: %d", len(ephemeralResourceSchemas))
+
+			// Log some resource names for verification
+			for name := range resourceSchemas {
+				t.Logf("Resource: %s", name)
+			}
+
+			// Log some data source names for verification
+			for name := range dataSourceSchemas {
+				t.Logf("Data source: %s", name)
+			}
+
+			// Log some ephemeral resource names for verification
+			for name := range ephemeralResourceSchemas {
+				t.Logf("Ephemeral resource: %s", name)
+			}
+
+			azapiResource, err := s.GetResourceSchema(request, "azapi_resource")
+			require.NoError(t, err)
+			require.NotNil(t, azapiResource)
+			azapiResourceJson, err := json.Marshal(azapiResource)
+			require.NoError(t, err)
+			t.Logf("azapi_resource schema: %s", string(azapiResourceJson))
+
+			providerSchema, err = s.GetProviderSchema(request)
+			require.NoError(t, err)
+			require.NotNil(t, providerSchema)
+
+			providerSchemaJson, err := json.Marshal(providerSchema)
+			require.NoError(t, err)
+
+			t.Logf("Provider schema: %s", string(providerSchemaJson))
+		})
 	}
-
-	// Log some data source names for verification
-	for name := range dataSourceSchemas {
-		t.Logf("Data source: %s", name)
-	}
-
-	// Log some ephemeral resource names for verification
-	for name := range ephemeralResourceSchemas {
-		t.Logf("Ephemeral resource: %s", name)
-	}
-
-	azapiResource, err := s.GetResourceSchema(request, "azapi_resource")
-	require.NoError(t, err)
-	require.NotNil(t, azapiResource)
-	azapiResourceJson, err := json.Marshal(azapiResource)
-	require.NoError(t, err)
-	t.Logf("azapi_resource schema: %s", string(azapiResourceJson))
-
-	providerSchema, err = s.GetProviderSchema(request)
-	require.NoError(t, err)
-	require.NotNil(t, providerSchema)
-
-	providerSchemaJson, err := json.Marshal(providerSchema)
-	require.NoError(t, err)
-
-	t.Logf("Provider schema: %s", string(providerSchemaJson))
 }
 
 func TestServer_AzureRM(t *testing.T) {
-	s := NewServer(nil)
-	defer s.Cleanup()
-
-	request := Request{
-		Namespace: "hashicorp",
-		Name:      "azurerm",
-		Version:   "4.37.0",
+	registries := []struct {
+		name         string
+		registryType RegistryType
+	}{
+		{"OpenTofu", RegistryTypeOpenTofu},
+		{"Terraform", RegistryTypeTerraform},
 	}
 
-	// Download and extract the provider
-	require.NoError(t, s.Get(request))
-	assert.Len(t, s.dlc, 1)
+	for _, reg := range registries {
+		t.Run(reg.name, func(t *testing.T) {
+			s := NewServer(nil)
+			defer s.Cleanup()
 
-	// Get schema
-	schema, err := s.getSchema(request)
-	require.NoError(t, err)
-	require.NotNil(t, schema)
+			request := Request{
+				Namespace:    "hashicorp",
+				Name:         "azurerm",
+				Version:      "4.37.0",
+				RegistryType: reg.registryType,
+			}
 
-	// Check that we got actual schema data
-	resourceSchemas := schema.ResourceSchemas
-	dataSourceSchemas := schema.DataSourceSchemas
+			// Download and extract the provider
+			require.NoError(t, s.Get(request))
+			assert.Len(t, s.dlc, 1)
 
-	require.NotNil(t, resourceSchemas, "Should have resource_schemas field")
-	require.NotNil(t, dataSourceSchemas, "Should have data_source_schemas field")
-	require.Greater(t, len(resourceSchemas), 0, "Should have resource schemas")
-	require.Greater(t, len(dataSourceSchemas), 0, "Should have data source schemas")
+			// Get schema
+			schema, err := s.getSchema(request)
+			require.NoError(t, err)
+			require.NotNil(t, schema)
 
-	t.Logf("Number of resource schemas: %d", len(resourceSchemas))
-	t.Logf("Number of data source schemas: %d", len(dataSourceSchemas))
+			// Check that we got actual schema data
+			resourceSchemas := schema.ResourceSchemas
+			dataSourceSchemas := schema.DataSourceSchemas
 
-	// Log some resource names for verification
-	for name := range resourceSchemas {
-		t.Logf("Resource: %s", name)
-	}
+			require.NotNil(t, resourceSchemas, "Should have resource_schemas field")
+			require.NotNil(t, dataSourceSchemas, "Should have data_source_schemas field")
+			require.Greater(t, len(resourceSchemas), 0, "Should have resource schemas")
+			require.Greater(t, len(dataSourceSchemas), 0, "Should have data source schemas")
 
-	// Log some data source names for verification
-	for name := range dataSourceSchemas {
-		t.Logf("Data source: %s", name)
+			t.Logf("Number of resource schemas: %d", len(resourceSchemas))
+			t.Logf("Number of data source schemas: %d", len(dataSourceSchemas))
+
+			// Log some resource names for verification
+			for name := range resourceSchemas {
+				t.Logf("Resource: %s", name)
+			}
+
+			// Log some data source names for verification
+			for name := range dataSourceSchemas {
+				t.Logf("Data source: %s", name)
+			}
+		})
 	}
 }

--- a/server_registry_test.go
+++ b/server_registry_test.go
@@ -1,0 +1,145 @@
+package tfpluginschema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRequest_String_URLFormat tests that the URL format is correct for both registries
+func TestRequest_String(t *testing.T) {
+	tests := []struct {
+		name            string
+		request         Request
+		expectedStrings []string
+	}{
+		{
+			name: "OpenTofu default",
+			request: Request{
+				Namespace: "Azure",
+				Name:      "azapi",
+				Version:   "2.7.0",
+			},
+			expectedStrings: []string{"registry.opentofu.org", "/Azure/azapi/2.7.0/"},
+		},
+		{
+			name: "Terraform explicit",
+			request: Request{
+				Namespace:    "Azure",
+				Name:         "azapi",
+				Version:      "2.7.0",
+				RegistryType: RegistryTypeTerraform,
+			},
+			expectedStrings: []string{"registry.terraform.io", "/Azure/azapi/2.7.0/"},
+		},
+		{
+			name: "OpenTofu explicit",
+			request: Request{
+				Namespace:    "Azure",
+				Name:         "azapi",
+				Version:      "2.7.0",
+				RegistryType: RegistryTypeOpenTofu,
+			},
+			expectedStrings: []string{"registry.opentofu.org", "/Azure/azapi/2.7.0/"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := tt.request.String()
+
+			// Check that URL starts with https://
+			assert.True(t, strings.HasPrefix(url, "https://"), "URL should start with https://")
+
+			for _, expected := range tt.expectedStrings {
+				// Check that URL contains expected host
+				assert.Contains(t, url, expected, "URL should contain expected registry host")
+			}
+
+			// Check that URL contains /v1/providers/
+			assert.Contains(t, url, "/v1/providers/", "URL should contain /v1/providers/")
+
+			// Check that URL contains the path components
+			expectedPath := "/" + tt.request.Namespace + "/" + tt.request.Name + "/" + tt.request.Version + "/download/"
+			assert.Contains(t, url, expectedPath, "URL should contain correct path")
+		})
+	}
+}
+
+// TestRegistryType_BaseURL tests the BaseURL method for different registry types
+func TestRegistryType_BaseURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		registryType RegistryType
+		expectedURL  string
+	}{
+		{
+			name:         "OpenTofu registry",
+			registryType: RegistryTypeOpenTofu,
+			expectedURL:  "https://registry.opentofu.org/v1/providers",
+		},
+		{
+			name:         "Terraform registry",
+			registryType: RegistryTypeTerraform,
+			expectedURL:  "https://registry.terraform.io/v1/providers",
+		},
+		{
+			name:         "Empty/default registry type",
+			registryType: "",
+			expectedURL:  "https://registry.opentofu.org/v1/providers",
+		},
+		{
+			name:         "Unknown registry type defaults to OpenTofu",
+			registryType: "unknown",
+			expectedURL:  "https://registry.opentofu.org/v1/providers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := tt.registryType.BaseURL()
+			assert.Equal(t, tt.expectedURL, url, "BaseURL should return expected URL")
+		})
+	}
+}
+
+// TestBackwardCompatibility_RequestWithoutRegistryType ensures existing code continues to work
+func TestBackwardCompatibility_RequestWithoutRegistryType(t *testing.T) {
+	// This simulates existing code that doesn't set RegistryType
+	req := Request{
+		Namespace: "hashicorp",
+		Name:      "random",
+		Version:   "3.6.0",
+		// RegistryType is not set (zero value)
+	}
+
+	url := req.String()
+
+	// Should default to OpenTofu registry
+	assert.Contains(t, url, "registry.opentofu.org", "Backward compatibility: should default to OpenTofu")
+	assert.Contains(t, url, "https://registry.opentofu.org/v1/providers/hashicorp/random/3.6.0/download/")
+}
+
+// TestBackwardCompatibility_VersionsRequestWithoutRegistryType ensures existing code continues to work
+func TestBackwardCompatibility_VersionsRequestWithoutRegistryType(t *testing.T) {
+	// This simulates existing code that doesn't set RegistryType
+	req := VersionsRequest{
+		Namespace: "hashicorp",
+		Name:      "aws",
+		// RegistryType is not set (zero value)
+	}
+
+	url := req.String()
+
+	// Should default to OpenTofu registry
+	assert.Contains(t, url, "registry.opentofu.org", "Backward compatibility: should default to OpenTofu")
+	assert.Contains(t, url, "https://registry.opentofu.org/v1/providers/hashicorp/aws/versions")
+}
+
+// TestRegistryTypeConstants verifies that the constants are defined correctly
+func TestRegistryTypeConstants(t *testing.T) {
+	assert.Equal(t, RegistryType("opentofu"), RegistryTypeOpenTofu, "OpenTofu constant should be 'opentofu'")
+	assert.Equal(t, RegistryType("terraform"), RegistryTypeTerraform, "Terraform constant should be 'terraform'")
+	assert.NotEqual(t, RegistryTypeOpenTofu, RegistryTypeTerraform, "Constants should be different")
+}

--- a/versions.go
+++ b/versions.go
@@ -22,13 +22,14 @@ type pluginApiVersionsResponse struct {
 }
 
 type VersionsRequest struct {
-	Namespace string
-	Name      string
+	Namespace    string       // Namespace of the provider (e.g., "hashicorp")
+	Name         string       // Name of the provider (e.g., "aws")
+	RegistryType RegistryType // Registry to use (defaults to OpenTofu if not specified)
 }
 
 func (v VersionsRequest) String() string {
 	sb := strings.Builder{}
-	sb.WriteString(pluginApi)
+	sb.WriteString(v.RegistryType.BaseURL())
 	sb.WriteRune(urlPathSeparator)
 	sb.WriteString(v.Namespace)
 	sb.WriteRune(urlPathSeparator)


### PR DESCRIPTION
Add optional RegistryType field to Request and VersionsRequest structs to allow users to specify which provider registry to use (OpenTofu or Terraform). Defaults to OpenTofu registry for backward compatibility.

Changes:
- Add RegistryType type with constants for OpenTofu and Terraform
- Add BaseURL() method to return appropriate registry URL
- Update Request and VersionsRequest structs with optional RegistryType field
- Update URL generation logic to support both registries
- Add comprehensive unit tests (11 tests) for registry functionality
- Update integration tests to verify both registries
- Add example demonstrating Terraform registry usage

All existing tests pass with zero regressions. Backward compatibility is maintained - existing code without RegistryType continues to work and defaults to OpenTofu registry.

Implements TDD workflow with tests written first.