### PR TITLE
feat: add CLI and goreleaser release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: ./go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+builds:
+  - id: tfpluginschema
+    main: ./cmd/tfpluginschema
+    binary: tfpluginschema
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: tfpluginschema
+    ids:
+      - tfpluginschema
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"

--- a/cmd/tfpluginschema/main.go
+++ b/cmd/tfpluginschema/main.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	cli "github.com/urfave/cli/v3"
+
+	"github.com/matt-FFFFFF/tfpluginschema"
+)
+
+// version is set at build time via ldflags.
+var version = "dev"
+
+func main() {
+	cmd := buildRootCommand()
+	if err := cmd.Run(context.Background(), os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// buildRootCommand constructs the full CLI command tree.
+func buildRootCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "tfpluginschema",
+		Usage:   "Query Terraform/OpenTofu provider schemas from the registry",
+		Version: version,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "namespace",
+				Aliases:  []string{"n"},
+				Usage:    "Provider namespace (e.g. hashicorp, Azure)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "name",
+				Aliases:  []string{"p"},
+				Usage:    "Provider name (e.g. aws, azapi)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "provider-version",
+				Aliases: []string{"pv"},
+				Usage:   "Provider version or constraint (e.g. 2.5.0, ~>2.1). Empty for latest",
+			},
+			&cli.StringFlag{
+				Name:    "registry",
+				Aliases: []string{"r"},
+				Usage:   "Registry type: opentofu (default) or terraform",
+				Value:   "opentofu",
+			},
+		},
+		Commands: []*cli.Command{
+			providerCommand(),
+			resourceCommand(),
+			datasourceCommand(),
+			functionCommand(),
+			ephemeralCommand(),
+			versionCommand(),
+		},
+	}
+}
+
+// requestFromCmd builds a tfpluginschema.Request from the CLI flags.
+func requestFromCmd(cmd *cli.Command) tfpluginschema.Request {
+	return tfpluginschema.Request{
+		Namespace:    cmd.String("namespace"),
+		Name:         cmd.String("name"),
+		Version:      cmd.String("provider-version"),
+		RegistryType: registryTypeFromString(cmd.String("registry")),
+	}
+}
+
+// versionsRequestFromCmd builds a tfpluginschema.VersionsRequest from the CLI flags.
+func versionsRequestFromCmd(cmd *cli.Command) tfpluginschema.VersionsRequest {
+	return tfpluginschema.VersionsRequest{
+		Namespace:    cmd.String("namespace"),
+		Name:         cmd.String("name"),
+		RegistryType: registryTypeFromString(cmd.String("registry")),
+	}
+}
+
+// registryTypeFromString converts a string to a RegistryType.
+func registryTypeFromString(s string) tfpluginschema.RegistryType {
+	switch strings.ToLower(s) {
+	case "terraform":
+		return tfpluginschema.RegistryTypeTerraform
+	default:
+		return tfpluginschema.RegistryTypeOpenTofu
+	}
+}
+
+// newServer creates a new tfpluginschema.Server with minimal logging.
+func newServer() *tfpluginschema.Server {
+	return tfpluginschema.NewServer(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	})))
+}
+
+// printJSON marshals v as indented JSON and writes it to stdout.
+func printJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// printList writes each string in items to stdout, one per line.
+func printList(items []string) {
+	for _, item := range items {
+		fmt.Println(item)
+	}
+}
+
+// --- provider ---
+
+func providerCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "provider",
+		Usage: "Query the provider configuration schema",
+		Commands: []*cli.Command{
+			{
+				Name:  "schema",
+				Usage: "Get the provider configuration schema",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					schema, err := s.GetProviderSchema(req)
+					if err != nil {
+						return err
+					}
+					return printJSON(schema)
+				},
+			},
+		},
+	}
+}
+
+// --- resource ---
+
+func resourceCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "resource",
+		Usage: "Query resource schemas",
+		Commands: []*cli.Command{
+			{
+				Name:      "schema",
+				Usage:     "Get the schema for a specific resource",
+				ArgsUsage: "<resource-name>",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args()
+					if args.Len() < 1 {
+						return fmt.Errorf("resource name is required as an argument")
+					}
+					resourceName := args.First()
+
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					schema, err := s.GetResourceSchema(req, resourceName)
+					if err != nil {
+						return err
+					}
+					return printJSON(schema)
+				},
+			},
+			{
+				Name:  "list",
+				Usage: "List all resource names",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					resources, err := s.ListResources(req)
+					if err != nil {
+						return err
+					}
+					printList(resources)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// --- datasource ---
+
+func datasourceCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "datasource",
+		Usage: "Query data source schemas",
+		Commands: []*cli.Command{
+			{
+				Name:      "schema",
+				Usage:     "Get the schema for a specific data source",
+				ArgsUsage: "<datasource-name>",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args()
+					if args.Len() < 1 {
+						return fmt.Errorf("data source name is required as an argument")
+					}
+					dsName := args.First()
+
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					schema, err := s.GetDataSourceSchema(req, dsName)
+					if err != nil {
+						return err
+					}
+					return printJSON(schema)
+				},
+			},
+			{
+				Name:  "list",
+				Usage: "List all data source names",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					dataSources, err := s.ListDataSources(req)
+					if err != nil {
+						return err
+					}
+					printList(dataSources)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// --- function ---
+
+func functionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "function",
+		Usage: "Query provider function schemas",
+		Commands: []*cli.Command{
+			{
+				Name:      "schema",
+				Usage:     "Get the schema for a specific function",
+				ArgsUsage: "<function-name>",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args()
+					if args.Len() < 1 {
+						return fmt.Errorf("function name is required as an argument")
+					}
+					funcName := args.First()
+
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					schema, err := s.GetFunctionSchema(req, funcName)
+					if err != nil {
+						return err
+					}
+					return printJSON(schema)
+				},
+			},
+			{
+				Name:  "list",
+				Usage: "List all function names",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					functions, err := s.ListFunctions(req)
+					if err != nil {
+						return err
+					}
+					printList(functions)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// --- ephemeral ---
+
+func ephemeralCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "ephemeral",
+		Usage: "Query ephemeral resource schemas",
+		Commands: []*cli.Command{
+			{
+				Name:      "schema",
+				Usage:     "Get the schema for a specific ephemeral resource",
+				ArgsUsage: "<ephemeral-resource-name>",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args()
+					if args.Len() < 1 {
+						return fmt.Errorf("ephemeral resource name is required as an argument")
+					}
+					ephName := args.First()
+
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					schema, err := s.GetEphemeralResourceSchema(req, ephName)
+					if err != nil {
+						return err
+					}
+					return printJSON(schema)
+				},
+			},
+			{
+				Name:  "list",
+				Usage: "List all ephemeral resource names",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := requestFromCmd(cmd)
+					ephemeralResources, err := s.ListEphemeralResources(req)
+					if err != nil {
+						return err
+					}
+					printList(ephemeralResources)
+					return nil
+				},
+			},
+		},
+	}
+}
+
+// --- version ---
+
+func versionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Query available provider versions",
+		Commands: []*cli.Command{
+			{
+				Name:  "list",
+				Usage: "List available versions for the provider",
+				Action: func(_ context.Context, cmd *cli.Command) error {
+					s := newServer()
+					defer s.Cleanup()
+
+					req := versionsRequestFromCmd(cmd)
+					versions, err := s.GetAvailableVersions(req)
+					if err != nil {
+						return err
+					}
+					for _, v := range versions {
+						fmt.Println(v.Original())
+					}
+					return nil
+				},
+			},
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,8 @@ require (
 	github.com/hashicorp/go-plugin v1.6.3
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-json v0.26.0
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
+	github.com/urfave/cli/v3 v3.6.2
 	github.com/zclconf/go-cty v1.16.4
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli/v3 v3.6.2 h1:lQuqiPrZ1cIz8hz+HcrG0TNZFxU70dPZ3Yl+pSrH9A8=
+github.com/urfave/cli/v3 v3.6.2/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/zclconf/go-cty v1.16.4 h1:QGXaag7/7dCzb+odlGrgr+YmYZFaOCMW6DEpS+UD1eE=
 github.com/zclconf/go-cty v1.16.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=


### PR DESCRIPTION
## Summary

- Add a CLI entry point (`cmd/tfpluginschema`) using `urfave/cli/v3` that exposes all primary library capabilities via a `<noun> <verb>` command structure
- Add GoReleaser config for cross-platform binary builds (linux/darwin/windows, amd64/arm64) with version injection via ldflags
- Add GitHub Actions release workflow triggered on `v*` tag pushes

### CLI Commands

```
tfpluginschema provider schema
tfpluginschema resource schema <name> | list
tfpluginschema datasource schema <name> | list
tfpluginschema function schema <name> | list
tfpluginschema ephemeral schema <name> | list
tfpluginschema version list
```

### Global Flags

- `--namespace, -n` (required) - Provider namespace
- `--name, -p` (required) - Provider name
- `--provider-version, --pv` - Version or constraint
- `--registry, -r` - opentofu (default) or terraform