### PR TITLE
feat!: harmonize CLI flags with tfmoduleschema

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,66 @@ defer server.Cleanup()
 // Server will now use custom logger for all operations
 ```
 
+## CLI
+
+```
+tfpluginschema --ns <namespace> -n <name> \
+  [--version-constraint VERSION] [--registry opentofu|terraform] \
+  <command>
+```
+
+Global flags:
+
+| Flag | Short | Description |
+|---|---|---|
+| `--namespace` | `--ns` | Provider namespace (required). |
+| `--name` | `-n` | Provider name (required). |
+| `--version-constraint` | `--vc` | Concrete version or constraint. Empty = latest. |
+| `--registry` | `-r` | `opentofu` (default) or `terraform`. |
+| `--cache-dir` | | Cache directory. Overrides `$TFPLUGINSCHEMA_CACHE_DIR`. |
+| `--force-fetch` | | Always re-download. |
+| `--quiet` | | Suppress `cache hit:` / `downloading:` status on stderr. |
+
+Commands:
+
+| Command | Description |
+|---|---|
+| `provider schema` | Provider configuration schema as JSON. |
+| `resource list` | Newline-separated resource type names. |
+| `resource schema [name]` | Full schema for one resource, or all. |
+| `datasource list` | Newline-separated data source names. |
+| `datasource schema [name]` | Full schema for one data source, or all. |
+| `function list` | Newline-separated function names. |
+| `function schema [name]` | Full schema for one function, or all. |
+| `ephemeral list` | Newline-separated ephemeral resource names. |
+| `ephemeral schema [name]` | Full schema for one ephemeral resource, or all. |
+| `version list` | All versions the registry advertises. |
+
+### Examples
+
+```bash
+# List versions (OpenTofu registry by default).
+tfpluginschema --ns hashicorp -n aws version list
+
+# Provider configuration schema, pinned version.
+tfpluginschema --ns hashicorp -n aws --vc 5.0.0 provider schema
+
+# Just the resource type names for the latest version.
+tfpluginschema --ns hashicorp -n aws resource list
+
+# Schema for one resource.
+tfpluginschema --ns hashicorp -n aws --vc 5.0.0 resource schema aws_instance
+
+# Schema for one data source.
+tfpluginschema --ns hashicorp -n aws --vc 5.0.0 datasource schema aws_ami
+
+# Use the HashiCorp registry.
+tfpluginschema -r terraform --ns Azure -n azapi resource list
+
+# Dump every resource schema at once.
+tfpluginschema --ns hashicorp -n aws --vc 5.0.0 resource schema
+```
+
 ## Architecture
 
 The library consists of several key components:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ tfpluginschema --ns <namespace> -n <name> \
 
 Global flags:
 
-| Flag | Short | Description |
+| Flag | Alias | Description |
 |---|---|---|
 | `--namespace` | `--ns` | Provider namespace (required). |
 | `--name` | `-n` | Provider name (required). |

--- a/cmd/tfpluginschema/main.go
+++ b/cmd/tfpluginschema/main.go
@@ -33,20 +33,20 @@ func buildRootCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "namespace",
-				Aliases:  []string{"n"},
+				Aliases:  []string{"ns"},
 				Usage:    "Provider namespace (e.g. hashicorp, Azure)",
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "name",
-				Aliases:  []string{"p"},
+				Aliases:  []string{"n"},
 				Usage:    "Provider name (e.g. aws, azapi)",
 				Required: true,
 			},
 			&cli.StringFlag{
-				Name:    "provider-version",
-				Aliases: []string{"pv"},
-				Usage:   "Provider version or constraint (e.g. 2.5.0, ~>2.1). Empty for latest",
+				Name:    "version-constraint",
+				Aliases: []string{"vc"},
+				Usage:   "Version or constraint (e.g. 2.5.0, ~>2.1). Empty for latest",
 			},
 			&cli.StringFlag{
 				Name:    "registry",
@@ -84,7 +84,7 @@ func requestFromCmd(cmd *cli.Command) tfpluginschema.Request {
 	return tfpluginschema.Request{
 		Namespace:    cmd.String("namespace"),
 		Name:         cmd.String("name"),
-		Version:      cmd.String("provider-version"),
+		Version:      cmd.String("version-constraint"),
 		RegistryType: registryTypeFromString(cmd.String("registry")),
 	}
 }
@@ -181,24 +181,34 @@ func resourceCommand() *cli.Command {
 		Commands: []*cli.Command{
 			{
 				Name:      "schema",
-				Usage:     "Get the schema for a specific resource",
-				ArgsUsage: "<resource-name>",
+				Usage:     "Get the schema for one resource, or all when no name given",
+				ArgsUsage: "[resource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
-					args := cmd.Args()
-					if args.Len() < 1 {
-						return fmt.Errorf("resource name is required as an argument")
-					}
-					resourceName := args.First()
-
 					s := newServer(cmd)
 					defer s.Cleanup()
-
 					req := requestFromCmd(cmd)
-					schema, err := s.GetResourceSchema(req, resourceName)
+
+					if name := cmd.Args().First(); name != "" {
+						schema, err := s.GetResourceSchema(req, name)
+						if err != nil {
+							return err
+						}
+						return printJSON(schema)
+					}
+
+					names, err := s.ListResources(req)
 					if err != nil {
 						return err
 					}
-					return printJSON(schema)
+					all := make(map[string]any, len(names))
+					for _, n := range names {
+						sc, err := s.GetResourceSchema(req, n)
+						if err != nil {
+							return err
+						}
+						all[n] = sc
+					}
+					return printJSON(all)
 				},
 			},
 			{
@@ -230,24 +240,34 @@ func datasourceCommand() *cli.Command {
 		Commands: []*cli.Command{
 			{
 				Name:      "schema",
-				Usage:     "Get the schema for a specific data source",
-				ArgsUsage: "<datasource-name>",
+				Usage:     "Get the schema for one data source, or all when no name given",
+				ArgsUsage: "[datasource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
-					args := cmd.Args()
-					if args.Len() < 1 {
-						return fmt.Errorf("data source name is required as an argument")
-					}
-					dsName := args.First()
-
 					s := newServer(cmd)
 					defer s.Cleanup()
-
 					req := requestFromCmd(cmd)
-					schema, err := s.GetDataSourceSchema(req, dsName)
+
+					if name := cmd.Args().First(); name != "" {
+						schema, err := s.GetDataSourceSchema(req, name)
+						if err != nil {
+							return err
+						}
+						return printJSON(schema)
+					}
+
+					names, err := s.ListDataSources(req)
 					if err != nil {
 						return err
 					}
-					return printJSON(schema)
+					all := make(map[string]any, len(names))
+					for _, n := range names {
+						sc, err := s.GetDataSourceSchema(req, n)
+						if err != nil {
+							return err
+						}
+						all[n] = sc
+					}
+					return printJSON(all)
 				},
 			},
 			{
@@ -279,24 +299,34 @@ func functionCommand() *cli.Command {
 		Commands: []*cli.Command{
 			{
 				Name:      "schema",
-				Usage:     "Get the schema for a specific function",
-				ArgsUsage: "<function-name>",
+				Usage:     "Get the schema for one function, or all when no name given",
+				ArgsUsage: "[function-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
-					args := cmd.Args()
-					if args.Len() < 1 {
-						return fmt.Errorf("function name is required as an argument")
-					}
-					funcName := args.First()
-
 					s := newServer(cmd)
 					defer s.Cleanup()
-
 					req := requestFromCmd(cmd)
-					schema, err := s.GetFunctionSchema(req, funcName)
+
+					if name := cmd.Args().First(); name != "" {
+						schema, err := s.GetFunctionSchema(req, name)
+						if err != nil {
+							return err
+						}
+						return printJSON(schema)
+					}
+
+					names, err := s.ListFunctions(req)
 					if err != nil {
 						return err
 					}
-					return printJSON(schema)
+					all := make(map[string]any, len(names))
+					for _, n := range names {
+						sc, err := s.GetFunctionSchema(req, n)
+						if err != nil {
+							return err
+						}
+						all[n] = sc
+					}
+					return printJSON(all)
 				},
 			},
 			{
@@ -328,24 +358,34 @@ func ephemeralCommand() *cli.Command {
 		Commands: []*cli.Command{
 			{
 				Name:      "schema",
-				Usage:     "Get the schema for a specific ephemeral resource",
-				ArgsUsage: "<ephemeral-resource-name>",
+				Usage:     "Get the schema for one ephemeral resource, or all when no name given",
+				ArgsUsage: "[ephemeral-resource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
-					args := cmd.Args()
-					if args.Len() < 1 {
-						return fmt.Errorf("ephemeral resource name is required as an argument")
-					}
-					ephName := args.First()
-
 					s := newServer(cmd)
 					defer s.Cleanup()
-
 					req := requestFromCmd(cmd)
-					schema, err := s.GetEphemeralResourceSchema(req, ephName)
+
+					if name := cmd.Args().First(); name != "" {
+						schema, err := s.GetEphemeralResourceSchema(req, name)
+						if err != nil {
+							return err
+						}
+						return printJSON(schema)
+					}
+
+					names, err := s.ListEphemeralResources(req)
 					if err != nil {
 						return err
 					}
-					return printJSON(schema)
+					all := make(map[string]any, len(names))
+					for _, n := range names {
+						sc, err := s.GetEphemeralResourceSchema(req, n)
+						if err != nil {
+							return err
+						}
+						all[n] = sc
+					}
+					return printJSON(all)
 				},
 			},
 			{

--- a/cmd/tfpluginschema/main.go
+++ b/cmd/tfpluginschema/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	cli "github.com/urfave/cli/v3"
 
 	"github.com/matt-FFFFFF/tfpluginschema"
@@ -184,12 +185,17 @@ func resourceCommand() *cli.Command {
 				Usage:     "Get the schema for one resource, or all when no name given",
 				ArgsUsage: "[resource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args().Slice()
+					if len(args) > 1 {
+						return fmt.Errorf("expected at most 1 resource name, got %d", len(args))
+					}
+
 					s := newServer(cmd)
 					defer s.Cleanup()
 					req := requestFromCmd(cmd)
 
-					if name := cmd.Args().First(); name != "" {
-						schema, err := s.GetResourceSchema(req, name)
+					if len(args) == 1 {
+						schema, err := s.GetResourceSchema(req, args[0])
 						if err != nil {
 							return err
 						}
@@ -200,7 +206,7 @@ func resourceCommand() *cli.Command {
 					if err != nil {
 						return err
 					}
-					all := make(map[string]any, len(names))
+					all := make(map[string]*tfjson.Schema, len(names))
 					for _, n := range names {
 						sc, err := s.GetResourceSchema(req, n)
 						if err != nil {
@@ -243,12 +249,17 @@ func datasourceCommand() *cli.Command {
 				Usage:     "Get the schema for one data source, or all when no name given",
 				ArgsUsage: "[datasource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args().Slice()
+					if len(args) > 1 {
+						return fmt.Errorf("expected at most 1 data source name, got %d", len(args))
+					}
+
 					s := newServer(cmd)
 					defer s.Cleanup()
 					req := requestFromCmd(cmd)
 
-					if name := cmd.Args().First(); name != "" {
-						schema, err := s.GetDataSourceSchema(req, name)
+					if len(args) == 1 {
+						schema, err := s.GetDataSourceSchema(req, args[0])
 						if err != nil {
 							return err
 						}
@@ -259,7 +270,7 @@ func datasourceCommand() *cli.Command {
 					if err != nil {
 						return err
 					}
-					all := make(map[string]any, len(names))
+					all := make(map[string]*tfjson.Schema, len(names))
 					for _, n := range names {
 						sc, err := s.GetDataSourceSchema(req, n)
 						if err != nil {
@@ -302,12 +313,17 @@ func functionCommand() *cli.Command {
 				Usage:     "Get the schema for one function, or all when no name given",
 				ArgsUsage: "[function-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args().Slice()
+					if len(args) > 1 {
+						return fmt.Errorf("expected at most 1 function name, got %d", len(args))
+					}
+
 					s := newServer(cmd)
 					defer s.Cleanup()
 					req := requestFromCmd(cmd)
 
-					if name := cmd.Args().First(); name != "" {
-						schema, err := s.GetFunctionSchema(req, name)
+					if len(args) == 1 {
+						schema, err := s.GetFunctionSchema(req, args[0])
 						if err != nil {
 							return err
 						}
@@ -318,7 +334,7 @@ func functionCommand() *cli.Command {
 					if err != nil {
 						return err
 					}
-					all := make(map[string]any, len(names))
+					all := make(map[string]*tfjson.FunctionSignature, len(names))
 					for _, n := range names {
 						sc, err := s.GetFunctionSchema(req, n)
 						if err != nil {
@@ -361,12 +377,17 @@ func ephemeralCommand() *cli.Command {
 				Usage:     "Get the schema for one ephemeral resource, or all when no name given",
 				ArgsUsage: "[ephemeral-resource-name]",
 				Action: func(_ context.Context, cmd *cli.Command) error {
+					args := cmd.Args().Slice()
+					if len(args) > 1 {
+						return fmt.Errorf("expected at most 1 ephemeral resource name, got %d", len(args))
+					}
+
 					s := newServer(cmd)
 					defer s.Cleanup()
 					req := requestFromCmd(cmd)
 
-					if name := cmd.Args().First(); name != "" {
-						schema, err := s.GetEphemeralResourceSchema(req, name)
+					if len(args) == 1 {
+						schema, err := s.GetEphemeralResourceSchema(req, args[0])
 						if err != nil {
 							return err
 						}
@@ -377,7 +398,7 @@ func ephemeralCommand() *cli.Command {
 					if err != nil {
 						return err
 					}
-					all := make(map[string]any, len(names))
+					all := make(map[string]*tfjson.Schema, len(names))
 					for _, n := range names {
 						sc, err := s.GetEphemeralResourceSchema(req, n)
 						if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matt-FFFFFF/tfpluginschema
 
-go 1.25.0
+go 1.26.1
 
 require (
 	github.com/hashicorp/go-hclog v1.6.3


### PR DESCRIPTION
## Summary

- Bring the `tfpluginschema` CLI in line with the `tfmoduleschema` CLI so users can switch tools without relearning flags.
- **Breaking**: flag renames (`--namespace`/`--ns`, `--name`/`-n`, `--version-constraint`/`--vc`) and new no-arg behavior for `<noun> schema`.

## Changes

- `cmd/tfpluginschema/main.go`:
  - `--namespace` short alias `-n` → `--ns`.
  - `--name` short alias `-p` → `-n`.
  - `--provider-version` / `-pv` → `--version-constraint` / `--vc`.
  - `resource schema`, `datasource schema`, `function schema`, `ephemeral schema` now print **all** schemas as JSON when invoked without a name argument (previously errored). Single-name behavior unchanged.
- `go.mod`: bump `go` directive from `1.25.0` → `1.26.1` (harmonized across both repos).
- `README.md`: add a **CLI** section with global-flag table, command table, and examples.

## Verification

- `go build ./...` — OK
- `go test -short ./...` — OK (18s)

## Notes

- Clean break, no deprecation window (tool is pre-1.0 and low-traffic).
- Companion PR in `tfmoduleschema` applies the mirror-image rename there: https://github.com/matt-FFFFFF/tfmoduleschema (link forthcoming).