### PR TITLE
ci: bump pinned actions and lock goreleaser to ~> v2

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ./go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ./go.mod
 
       - name: Generate Homebrew tap token
         id: tap-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.HOMEBREW_TAP_APP_CLIENT_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
@@ -34,9 +34,13 @@ jobs:
           repositories: homebrew-tap
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
-          version: latest
+          # Pin to the v2 line so a future v3 release cannot silently
+          # change behaviour here. 'latest' would otherwise opt us in
+          # to whatever major is current, which goreleaser-action now
+          # warns against.
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Silences the Node.js 20 deprecation warnings by bumping all pinned actions to their latest Node 24 majors.
- Replaces `version: latest` on the GoReleaser step with `version: \"~> v2\"`, which is what goreleaser-action itself recommends (it emits a runtime warning against `latest`) and which locks us to the v2 line so a future v3 release can't silently change release output.

## Changes

- `actions/checkout`: `v5.0.0` → `v6.0.2`
- `actions/setup-go`: `v6.0.0` → `v6.4.0`
- `actions/create-github-app-token`: `v2.2.2` → `v3.1.1`
- `goreleaser/goreleaser-action`: `v6.3.0` → `v7.1.0`
- GoReleaser CLI: `latest` → `~> v2`

All actions remain pinned to commit SHAs with the tag in a trailing comment.

## Verification

- `actions/create-github-app-token` v3 removed custom proxy handling — this workflow does not set `HTTP_PROXY` / `HTTPS_PROXY`, so the change is a no-op here.
- `actions/create-github-app-token` v3 requires runner v2.327.1+ on self-hosted runners; we use `ubuntu-latest`, so this is a non-issue.
- Other major bumps are Node 20 → Node 24 runtime moves with no API-surface changes that affect this workflow.
- The `release.yml` path will only be exercised on the next tag push (no PR CI for it). `go-test.yml` runs on this PR and will exercise the updated checkout + setup-go pins.